### PR TITLE
feat: find prev/last tag

### DIFF
--- a/cmd/chlog/main.go
+++ b/cmd/chlog/main.go
@@ -32,6 +32,7 @@ var opts = struct {
 	configFile string
 	outputFile string
 	sha1, sha2 string
+	tagType    int
 }{}
 
 var cfg = chlog.NewDefaultConfig()
@@ -60,6 +61,7 @@ func configCmd() {
 	cmd.StringVar(&opts.configFile, "config", "", "the YAML config file for generate changelog;;c")
 	cmd.StringVar(&opts.outputFile, "output", "stdout", "the output file for generated changelog;;o")
 	cmd.StringVar(&opts.excludes, "exclude", "", "exclude commit by keywords, multi split by comma")
+	cmd.IntVar(&opts.tagType, "tagType", 0, "get tag by tag type, tag_type: 0 refname_sort,1 createordate sort,2 describe command")
 
 	cmd.AddArg("sha1", "The old git sha version. allow: tag name, commit id", true, nil)
 	cmd.AddArg("sha2", "The new git sha version. allow: tag name, commit id", false, nil)
@@ -154,8 +156,8 @@ func generate(cl *chlog.Changelog) error {
 		gitArgs = append(gitArgs, "--no-merges")
 	}
 
-	sha1 := repo.AutoMatchTag(opts.sha1)
-	sha2 := repo.AutoMatchTag(opts.sha2)
+	sha1 := repo.AutoMatchTagByTagType(opts.sha1, opts.tagType)
+	sha2 := repo.AutoMatchTagByTagType(opts.sha2, opts.tagType)
 	cliutil.Infof("Generate changelog: %s to %s\n", sha1, sha2)
 
 	cl.FetchGitLog(sha1, sha2, gitArgs...)

--- a/repo.go
+++ b/repo.go
@@ -126,17 +126,17 @@ const ShaHead = "HEAD"
 
 // some special keywords for match tag
 const (
-	TagLast         = "last"
-	TagPrev         = "prev"
-	TagHead         = "head"
-	Refname_tag int = iota
-	Creatordate_tag
-	Describe_tag
+	TagLast            = "last"
+	TagPrev            = "prev"
+	TagHead            = "head"
+	RefnameTagType int = iota
+	CreatordateTagType
+	DescribeTagType
 )
 
 // AutoMatchTag by given sha or tag name
 func (r *Repo) AutoMatchTag(sha string) string {
-	return r.AutoMatchTagByTagType(sha, Refname_tag)
+	return r.AutoMatchTagByTagType(sha, RefnameTagType)
 }
 
 // AutoMatchTagByTagType by given sha or tag name
@@ -174,6 +174,7 @@ func (r *Repo) LargestTag() string {
 	return ""
 }
 
+// LargestTagByTagType get max tag version of the repo by tag_type
 func (r *Repo) LargestTagByTagType(tagType int) string {
 	tagVer := r.cache.Str(cacheMaxTagVersion)
 	if len(tagVer) > 0 {
@@ -181,10 +182,10 @@ func (r *Repo) LargestTagByTagType(tagType int) string {
 	}
 	tags := make([]string, 0)
 	switch tagType {
-	case Creatordate_tag:
+	case CreatordateTagType:
 		tags = append(tags, r.TagsSortedByCreatordate()...)
 		break
-	case Describe_tag:
+	case DescribeTagType:
 		tags = append(tags, r.TagByDescribe(""))
 		break
 	default:
@@ -212,14 +213,14 @@ func (r *Repo) TagSecondMax() string {
 	return ""
 }
 
-// TagSecondMaxByTagType  get second-largest tag of the repo
+// TagSecondMaxByTagType  get second-largest tag of the repo by tag_type
 func (r *Repo) TagSecondMaxByTagType(tagType int) string {
 	tags := make([]string, 0)
 	switch tagType {
-	case Creatordate_tag:
+	case CreatordateTagType:
 		tags = append(tags, r.TagsSortedByCreatordate()...)
 		break
-	case Describe_tag:
+	case DescribeTagType:
 		current := r.TagByDescribe("")
 		if len(current) == 0 {
 			break

--- a/repo.go
+++ b/repo.go
@@ -184,10 +184,8 @@ func (r *Repo) LargestTagByTagType(tagType int) string {
 	switch tagType {
 	case CreatordateTagType:
 		tags = append(tags, r.TagsSortedByCreatordate()...)
-		break
 	case DescribeTagType:
 		tags = append(tags, r.TagByDescribe(""))
-		break
 	default:
 		tags = append(tags, r.TagsSortedByRefName()...)
 	}
@@ -219,14 +217,13 @@ func (r *Repo) TagSecondMaxByTagType(tagType int) string {
 	switch tagType {
 	case CreatordateTagType:
 		tags = append(tags, r.TagsSortedByCreatordate()...)
-		break
 	case DescribeTagType:
 		current := r.TagByDescribe("")
-		if len(current) == 0 {
-			break
+		if len(current) != 0 {
+			tags = append(tags, current, r.TagByDescribe(current))
+		} else {
+			tags = append(tags, current)
 		}
-		tags = append(tags, current, r.TagByDescribe(current))
-		break
 	default:
 		tags = append(tags, r.TagsSortedByRefName()...)
 	}

--- a/repo_test.go
+++ b/repo_test.go
@@ -79,3 +79,15 @@ func TestRepo_AutoMatchTagByTagType(t *testing.T) {
 	assert.Equal(t, "HEAD", repo.AutoMatchTagByTagType("head", 0))
 	assert.Equal(t, "541fb9d", repo.AutoMatchTagByTagType("541fb9d", 0))
 }
+
+func TestRepo_TagsSortedByCreatordate(t *testing.T) {
+	tags := repo.TagsSortedByCreatordate()
+	dump.P(tags)
+	assert.NotEmpty(t, tags)
+}
+
+func TestRepo_TagByDescribe(t *testing.T) {
+	tags := repo.TagByDescribe("")
+	dump.P(tags)
+	assert.NotEmpty(t, tags)
+}

--- a/repo_test.go
+++ b/repo_test.go
@@ -74,3 +74,8 @@ func TestRepo_Info(t *testing.T) {
 	assert.NotNil(t, info)
 	assert.Equal(t, "gitw", info.Name)
 }
+
+func TestRepo_AutoMatchTagByTagType(t *testing.T) {
+	assert.Equal(t, "HEAD", repo.AutoMatchTagByTagType("head", 0))
+	assert.Equal(t, "541fb9d", repo.AutoMatchTagByTagType("541fb9d", 0))
+}


### PR DESCRIPTION
获取prev/last tag方式为多种

* `refname` :  通过`git tag --sort=-v:refname`方式获取
* `creatordate` 通过`git tag --sort=-creatordate`方式获取
* `describe` : 通过`git describe --abbrev=0` 方式获取

#### link
* [describe](https://git-scm.com/docs/git-describe) 从提交中访问的最新标记

#### cmd
* `tagType` 获取tag方式
  * `0 refname` 默认方式
  * `1 creatordate` 通过创建时间
  * `2 describe` 提交记录最新标记

refer issues #31 

**不太常用go,有写不对,敬请指导**